### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Easy to use barcode reader for your Android Project (Uses Google Mobile Vision A
 
 **In active development so if you have a suggestion or feature request please feel free to open an issue!**
 
-###Overview
+### Overview
 - Integrate in a **few minutes**
 - Quick and simple api
 - No external apps required
@@ -17,14 +17,14 @@ Easy to use barcode reader for your Android Project (Uses Google Mobile Vision A
 - Supports 1D barcodes: EAN-13, EAN-8, UPC-A, UPC-E, Code-39, Code-93, Code-128, ITF, Codabar
 - Supports 2D barcodes: QR Code, Data Matrix, PDF-417, Aztec
 
-#Setup
-##1. Provide gradle dependency
+# Setup
+## 1. Provide gradle dependency
 
 ```gradle
 compile 'com.edwardvanraak:MaterialBarcodeScanner:0.0.6-ALPHA'
 ```
 
-##2. Build a MaterialBarcodeScanner
+## 2. Build a MaterialBarcodeScanner
 
 ```java
     private void startScan() {
@@ -61,13 +61,13 @@ compile 'com.edwardvanraak:MaterialBarcodeScanner:0.0.6-ALPHA'
         });
  ```
  
-##3. Start scanning!
+## 3. Start scanning!
 
 Check out the full [example project](https://github.com/EdwardvanRaak/MaterialBarcodeScanner/blob/master/app/src/main/java/com/edwardvanraak/materialbarcodescannerexample/MainActivity.java) for code required for camera permissions on Android 6.0 Marshmallow
 
-#Additional Setup
+# Additional Setup
 
-##Center tracking mode
+## Center tracking mode
 
 By default a barcode is tracked/highlighted at the location at which it was found.  
 With <i>center tracking mode</i> a square image will be shown during scanning that will turn green when a barcode is found.
@@ -83,7 +83,7 @@ If you want to provide your own image for the tracker you can use:
 ```
 <img src="https://raw.githubusercontent.com/EdwardvanRaak/MaterialBarcodeScanner/master/DEV/screens/center_tracker_screenshot.png" width="150">
 
-##Exclusive barcode scanning
+## Exclusive barcode scanning
 
 In some situations you might want to scan for only a certain type of barcode like QR-Codes or 2D barcodes. You can do this with the following builder methods:
 
@@ -98,10 +98,10 @@ If you want to scan for a very specific combination of barcodes you can setup th
 .withBarcodeFormats(Barcode.AZTEC | Barcode.EAN_13 | Barcode.CODE_93)		
 ```
 
-##Screenshots
+## Screenshots
 ![Image](https://raw.githubusercontent.com/EdwardvanRaak/MaterialBarcodeScanner/master/DEV/screens/screenshot1.png)
 
-#Developed By
+# Developed By
 
 * Edward van Raak
  * edwardvraak@gmail.com


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
